### PR TITLE
fix: GitHub Actions heredoc 문법 오류 수정

### DIFF
--- a/.github/workflows/backend-ci.yml
+++ b/.github/workflows/backend-ci.yml
@@ -447,9 +447,10 @@ jobs:
           
       - name: Create deployment directory on EC2
         run: |
-          ssh -i ~/.ssh/id_rsa ${{ secrets.EC2_USERNAME }}@${{ secrets.EC2_HOST }} << 'EOF'
-            mkdir -p ${{ env.DEPLOY_DIR }}
-            cd ${{ env.DEPLOY_DIR }}
+          DEPLOY_DIR="${{ env.DEPLOY_DIR }}"
+          ssh -i ~/.ssh/id_rsa ${{ secrets.EC2_USERNAME }}@${{ secrets.EC2_HOST }} << EOF
+            mkdir -p ${DEPLOY_DIR}
+            cd ${DEPLOY_DIR}
 EOF
           
       - name: Copy deployment files to EC2
@@ -475,11 +476,12 @@ EOF
           # 첫 번째 태그 추출
           IMAGE_TAGS="${{ needs.docker-build.outputs.image-tag }}"
           FIRST_TAG=$(echo "$IMAGE_TAGS" | head -1 | xargs)
+          DEPLOY_DIR="${{ env.DEPLOY_DIR }}"
           
-          ssh -i ~/.ssh/id_rsa ${{ secrets.EC2_USERNAME }}@${{ secrets.EC2_HOST }} << 'EOF'
-            cd ${{ env.DEPLOY_DIR }}
+          ssh -i ~/.ssh/id_rsa ${{ secrets.EC2_USERNAME }}@${{ secrets.EC2_HOST }} << EOF
+            cd ${DEPLOY_DIR}
             chmod +x deploy-backend.sh
-            ./deploy-backend.sh "$FIRST_TAG"
+            ./deploy-backend.sh "${FIRST_TAG}"
 EOF
           
           DEPLOY_RESULT=$?

--- a/.github/workflows/frontend-ci.yml
+++ b/.github/workflows/frontend-ci.yml
@@ -472,9 +472,10 @@ jobs:
           
       - name: Create deployment directory on EC2
         run: |
-          ssh -i ~/.ssh/id_rsa ${{ secrets.EC2_USERNAME }}@${{ secrets.EC2_HOST }} << 'EOF'
-            mkdir -p ${{ env.DEPLOY_DIR }}
-            cd ${{ env.DEPLOY_DIR }}
+          DEPLOY_DIR="${{ env.DEPLOY_DIR }}"
+          ssh -i ~/.ssh/id_rsa ${{ secrets.EC2_USERNAME }}@${{ secrets.EC2_HOST }} << EOF
+            mkdir -p ${DEPLOY_DIR}
+            cd ${DEPLOY_DIR}
 EOF
           
       - name: Copy deployment script to EC2
@@ -499,11 +500,12 @@ EOF
           # 첫 번째 태그 추출
           IMAGE_TAGS="${{ needs.docker-build.outputs.image-tag }}"
           FIRST_TAG=$(echo "$IMAGE_TAGS" | head -1 | xargs)
+          DEPLOY_DIR="${{ env.DEPLOY_DIR }}"
           
-          ssh -i ~/.ssh/id_rsa ${{ secrets.EC2_USERNAME }}@${{ secrets.EC2_HOST }} << 'EOF'
-            cd ${{ env.DEPLOY_DIR }}
+          ssh -i ~/.ssh/id_rsa ${{ secrets.EC2_USERNAME }}@${{ secrets.EC2_HOST }} << EOF
+            cd ${DEPLOY_DIR}
             chmod +x deploy-frontend.sh
-            ./deploy-frontend.sh "$FIRST_TAG"
+            ./deploy-frontend.sh "${FIRST_TAG}"
 EOF
           
           DEPLOY_RESULT=$?


### PR DESCRIPTION
## 📋 개요
PR #4 머지 후 발생한 GitHub Actions YAML 파싱 오류를 수정합니다.

## 🔍 문제 상황
- **오류 메시지**: `Invalid workflow file: .github/workflows/backend-ci.yml#L453`
- **원인**: heredoc 내부에서 GitHub Actions 변수(`${{ }}`)를 직접 사용

## 🛠️ 해결 방법
heredoc 사용 전에 GitHub Actions 변수를 쉘 변수로 추출:

```yaml
# Before (오류)
ssh user@host << 'EOF'
  cd ${{ env.DEPLOY_DIR }}
EOF

# After (정상)
DEPLOY_DIR="${{ env.DEPLOY_DIR }}"
ssh user@host << EOF
  cd ${DEPLOY_DIR}
EOF
```

## 📝 변경사항
- ✅ `backend-ci.yml`: heredoc 내부 변수 참조 수정
- ✅ `frontend-ci.yml`: heredoc 내부 변수 참조 수정
- ✅ quoted heredoc (`'EOF'`) → unquoted heredoc (`EOF`)로 변경

## ✅ 테스트
- [ ] GitHub Actions YAML 문법 검증 통과
- [ ] CI/CD 파이프라인 정상 실행 확인

## 🔗 관련 이슈
Resolves #5

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * 백엔드 및 프론트엔드 배포 워크플로우에서 원격 서버의 디렉토리 경로와 환경 변수 처리가 개선되었습니다.
  * 배포 스크립트 실행 시 변수 전달 및 인용 방식이 일관성 있게 수정되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->